### PR TITLE
Fix release workflow cache conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
-
       - name: Build binaries
         uses: cli/gh-extension-precompile@v2
         with:


### PR DESCRIPTION
## Summary
- Remove duplicate `actions/setup-go@v5` step from release workflow

## Problem
The release workflow had both `actions/setup-go@v5` and `cli/gh-extension-precompile@v2` which both try to set up Go and manage the module cache. This caused cache extraction conflicts:
```
/usr/bin/tar: Cannot open: File exists
```

## Solution
Remove the explicit `setup-go` step since `gh-extension-precompile` handles Go setup internally.

## Test Plan
- [ ] Merge and create new release tag
- [ ] Verify CLI binaries build successfully