### PR TITLE
Fix release workflow build path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: cli/gh-extension-precompile@v2
         with:
           go_version: '1.23'
+          build_script_override: "go build -o dist/$1 ./cmd/gh-simili"
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specify build path for Go binaries since main.go is in cmd/gh-simili/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration for CLI release automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->