### PR TITLE
Fix transferred issues being detected as self-duplicates

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -188,24 +188,9 @@ func (p *Processor) processOpened(ctx context.Context, issue *models.Issue, repo
 			result.Transferred = true
 			result.TransferTarget = target
 
-			// Index the transferred issue in the destination repo
-			if !p.dryRun {
-				targetOrg, targetRepo, _ := github.ParseRepo(target)
-				// Create issue object for destination (GitHub keeps same content)
-				destIssue := &models.Issue{
-					Org:    targetOrg,
-					Repo:   targetRepo,
-					Number: issue.Number, // Note: number may change, but we index with original content
-					Title:  issue.Title,
-					Body:   issue.Body,
-					Author: issue.Author,
-					State:  issue.State,
-					Labels: issue.Labels,
-				}
-				if err := p.indexer.IndexSingleIssue(ctx, destIssue); err != nil {
-					fmt.Printf("Warning: failed to index transferred issue in destination: %v\n", err)
-				}
-			}
+			// Don't index here - the destination repo's workflow will handle indexing
+			// with the correct issue number. Indexing here with source issue number
+			// causes self-duplicate detection when the destination workflow runs.
 
 			return result, nil
 		}


### PR DESCRIPTION
## Summary
- Fixes bug where transferred issues were closed as duplicates of themselves
- Removed premature indexing from source workflow that used wrong issue number
- Destination workflow now handles indexing with correct issue number

## Problem
When an issue was transferred:
1. Source workflow indexed with source issue number (#17)
2. Transfer created new issue in destination (#6)
3. Destination workflow found the wrongly-indexed entry at 100% similarity
4. Issue closed as duplicate of itself

## Test plan
- [ ] Create issue in source repo matching transfer rules
- [ ] Verify issue transfers correctly
- [ ] Verify no self-duplicate detection occurs
- [ ] Verify issue is indexed in destination with correct number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the issue transfer workflow by optimizing how destination repositories handle indexing after transfers. Destination issue indexing is now delegated to and managed by the destination repository's workflow handler, streamlining the overall transfer process and ensuring more reliable and consistent handling of transferred issues across different repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->